### PR TITLE
add seamless navigation between Neovim windows and terminal

### DIFF
--- a/lua/configs/lspconfig.lua
+++ b/lua/configs/lspconfig.lua
@@ -18,13 +18,12 @@ lspconfig.servers = {
     "dockerls",
     "yamlls",
     "ts_ls",
-    "eslint",
     "sqlls",
     "intelephense",
 }
 
 -- Define a list of LSP servers that will use the default configuration.
-local default_servers = { "pyright", "dockerls", "yamlls", "ts_ls", "eslint", "sqlls", "intelephense" }
+local default_servers = { "pyright", "dockerls", "yamlls", "ts_ls", "sqlls", "intelephense" }
 
 -- Loop through the list of servers with default configuration and apply them
 for _, lsp in ipairs(default_servers) do

--- a/lua/mappings.lua
+++ b/lua/mappings.lua
@@ -34,3 +34,19 @@ local tmux_maps = {
 for _, mapping in ipairs(tmux_maps) do
     map("n", mapping.key, mapping.cmd, vim.tbl_extend("force", opts, { desc = mapping.desc }))
 end
+
+-- ----------------------
+-- Terminal Mode Navigation Mappings (Tmux style)
+-- ----------------------
+
+-- Function to set terminal keymaps for navigation
+function _G.set_terminal_keymaps()
+    local term_opts = { noremap = true, silent = true }
+    vim.api.nvim_buf_set_keymap(0, "t", "<C-h>", "<C-\\><C-N><C-w>h", term_opts)
+    vim.api.nvim_buf_set_keymap(0, "t", "<C-j>", "<C-\\><C-N><C-w>j", term_opts)
+    vim.api.nvim_buf_set_keymap(0, "t", "<C-k>", "<C-\\><C-N><C-w>k", term_opts)
+    vim.api.nvim_buf_set_keymap(0, "t", "<C-l>", "<C-\\><C-N><C-w>l", term_opts)
+end
+
+-- Automatically set these keymaps when opening a terminal
+vim.cmd("autocmd! TermOpen term://* lua set_terminal_keymaps()")


### PR DESCRIPTION
- Added custom key mappings for Tmux-like navigation with Ctrl + h/j/k/l in Neovim.
- Implemented terminal-specific mappings to ensure smooth navigation between Neovim windows and the integrated terminal.
- Automatically set terminal navigation key mappings using an autocmd on terminal open.
- Removed ESLint as it was redundant with ts_ls for linting and formatting.